### PR TITLE
Lexer

### DIFF
--- a/ScanInputs.go
+++ b/ScanInputs.go
@@ -137,10 +137,8 @@ func SplitByInlinedPrefixN(text, delim string, n int) (parts []string) {
         }
 
         line := strings.TrimSpace(s.Text())
-        if line != "" {
-            str.WriteString(line)
-            str.WriteRune('\n')
-        }
+        str.WriteString(line)
+        str.WriteRune('\n')
     }
 
     part := str.String()

--- a/ScanInputs.go
+++ b/ScanInputs.go
@@ -114,9 +114,8 @@ func ScanConfig(text string) (m map[string]string, errs []error) {
 }
 
 // SplitByInlinedPrefxN works in the same way as strings.SplitN. However,
-// it does 2 additional things. First, it matches the *prefixes of the lines* 
+// it does one additional thing. It matches the *prefixes of the lines*
 // for equality with the delimeter. Upon match the entire line is discarded. 
-// Second, each line of the produced parts is space-trimmed.
 //
 // If text doesn't contain the delimeter, only one part is returned.
 // User can specify the number of parts they want at most via the third
@@ -136,8 +135,7 @@ func SplitByInlinedPrefixN(text, delim string, n int) (parts []string) {
             continue
         }
 
-        line := strings.TrimSpace(s.Text())
-        str.WriteString(line)
+        str.WriteString(s.Text())
         str.WriteRune('\n')
     }
 

--- a/ScanInputs.go
+++ b/ScanInputs.go
@@ -19,9 +19,6 @@ func (e InputsError) Error() string {
 const (
     IOSeparatorMissing = InputsError("IO separator missing")
     KeyMissing = InputsError("key cannot be empty")
-    ValueMissing = InputsError("value cannot be empty")
-    KVMissing = InputsError("key and value are missing")
-    NotKVPair = InputsError("not a key-value pair")
 )
 
 // LinedError appends line information to the error message. It is mainly used
@@ -53,17 +50,17 @@ type Test struct {
     Output string
 }
 
-// Inputs contains all information located in the inputs file. It contains
-// all of the tests listed there and the set of key-value pairs, if were
-// provided.
+// Inputs contains all information located in the inputs file: tests and
+// the set of key-value pairs that were provided.
 type Inputs struct {
     Tests []Test
     Config map[string]string
 }
 
-// ScanKeyValuePair parses the key-value pair definition of form key=value.
-// It returns error if no equality signs are present, or if any side is empty.
-// The space around key and value is trimmed.
+// ScanKeyValuePair parses the key-value pair of form 'key=value'.
+// Strings without assignment are treated as keys with empty value.
+// Strings with assignment but with empty key are erroneous.
+// The space around key and value respectively is trimmed.
 func ScanKeyValuePair(line string) (string, string, error) {
     parts := strings.SplitN(line, "=", 2)
 
@@ -74,22 +71,14 @@ func ScanKeyValuePair(line string) (string, string, error) {
             return "", "", nil
         }
 
-        return "", "", NotKVPair
+        return parts[0], "", nil
     }
 
     key := strings.TrimSpace(parts[0])
     val := strings.TrimSpace(parts[1])
 
-    if key == "" && val == "" {
-        return "", "", KVMissing
-    }
-
     if key == "" {
         return "", "", KeyMissing
-    }
-
-    if val == "" {
-        return "", "", ValueMissing
     }
 
     return key, val, nil

--- a/ScanInputs_test.go
+++ b/ScanInputs_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestScanTest(t *testing.T) {
 
-    t.Run("trim spaces",
+    t.Run("trim spaces but not \\n",
     func(t *testing.T) {
         want := cptest.Test{
-            Input: "5\n1 2 3 4 5\n",
-            Output: "5 4 3 2 1\n",
+            Input: "\n\n5\n1 2 3 4 5\n\n",
+            Output: "\n5 4 3 2 1\n\n\n\n",
         }
 
         text := `
@@ -49,7 +49,7 @@ trash%and%trash
             Output: "correct\n",
         }
 
-        text := fmt.Sprintf("%s\n%s\ncorrect", inputText, cptest.IODelim)
+        text := fmt.Sprintf("%s%s\ncorrect", inputText, cptest.IODelim)
 
         test, errs := cptest.ScanTest(text)
 
@@ -59,13 +59,11 @@ trash%and%trash
 
     t.Run("second+ IO delimeters are ignored",
     func(t *testing.T) {
-        text := `
-a
+        text := `a
 ---
 b
 ---
-c
-        `
+c`
 
         want := cptest.Test{
             Input: "a\n",
@@ -132,7 +130,7 @@ dcba
 
     t.Run("empty input",
     func(t *testing.T) {
-        test, errs := cptest.ScanTest("\n---\ntwo\n")
+        test, errs := cptest.ScanTest("---\ntwo\n")
 
         want := cptest.Test{
             Input: "",
@@ -206,8 +204,7 @@ func TestScanInputs(t *testing.T) {
             },
         }
 
-        text := `
-4
+        text := `4
 1 2 3 4
 ---
 4 3 2 1
@@ -221,7 +218,7 @@ func TestScanInputs(t *testing.T) {
 1
 ---
 1
-        `
+`
         text = strings.ReplaceAll(text, "---", cptest.IODelim)
         text = strings.ReplaceAll(text, "===", cptest.TestDelim)
 
@@ -302,7 +299,7 @@ xyz
 ---
 zyx
 ===
-        `
+`
         text = strings.ReplaceAll(text, "---", cptest.IODelim)
         text = strings.ReplaceAll(text, "===", cptest.TestDelim)
 
@@ -335,7 +332,7 @@ zyx
 --===
 ---
 ===---
-        `
+`
         text = strings.ReplaceAll(text, "---", cptest.IODelim)
         text = strings.ReplaceAll(text, "===", cptest.TestDelim)
 
@@ -370,7 +367,7 @@ extra=love
 2 2
 ---
 4
-        `
+`
         text = strings.ReplaceAll(text, "---", cptest.IODelim)
         text = strings.ReplaceAll(text, "===", cptest.TestDelim)
 

--- a/ScanInputs_test.go
+++ b/ScanInputs_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestScanTest(t *testing.T) {
 
-    t.Run("trim spaces but not \\n",
+    t.Run("don't trim space",
     func(t *testing.T) {
         want := cptest.Test{
-            Input: "\n\n5\n1 2 3 4 5\n\n",
-            Output: "\n5 4 3 2 1\n\n\n\n",
+            Input: "\n \n  5\n  1 2 3 4 5\n   \n",
+            Output: "\n  5 4 3 2 1\n\n  \n",
         }
 
         text := `
@@ -27,7 +27,7 @@ func TestScanTest(t *testing.T) {
   5 4 3 2 1
 
   
-        `
+`
 
         test, errs := cptest.ScanTest(text)
 

--- a/ScanInputs_test.go
+++ b/ScanInputs_test.go
@@ -455,34 +455,31 @@ foo=bar
         cptest.AssertNoErrors(t, errs)
     })
 
-    t.Run("lines without assignments are gibberish",
+    t.Run("lines without assignments are keys without values",
     func(t *testing.T) {
         text := `
 hi = owww
 key assign value
 zap = paz
-uoenahonetuhneo
+ignore_newline
+this is ok =
         `
 
         got, errs := cptest.ScanConfig(text)
 
         want := map[string]string{
             "hi": "owww",
+            "key assign value": "",
             "zap": "paz",
-        }
-
-        errLines := []int{3, 5}
-        errsWant := []error{
-            cptest.NotKVPair,
-            cptest.NotKVPair,
+            "ignore_newline": "",
+            "this is ok": "",
         }
 
         cptest.AssertConfig(t, got, want)
-        cptest.AssertErrorLines(t, errs, errLines)
-        cptest.AssertErrors(t, errs, errsWant)
+        cptest.AssertNoErrors(t, errs)
     })
 
-    t.Run("assignments with lhs or rhs empty are erroneous",
+    t.Run("assignments with empty lhs are erroneous",
     func(t *testing.T) {
         text := `
 foo=bar
@@ -495,15 +492,14 @@ foo=
         got, errs := cptest.ScanConfig(text)
 
         want := map[string]string{
-            "foo": "bar",
+            "foo": "",
         }
 
-        errLines := []int{3, 4, 5, 6}
+        errLines := []int{4, 5, 6}
         errsWant := []error{
-            cptest.ValueMissing,
             cptest.KeyMissing,
-            cptest.KVMissing,
-            cptest.KVMissing,
+            cptest.KeyMissing,
+            cptest.KeyMissing,
         }
 
         cptest.AssertConfig(t, got, want)

--- a/TestingBatch.go
+++ b/TestingBatch.go
@@ -163,13 +163,6 @@ func (b *TestingBatch) Run() {
 
         b.Times[id] = b.Swatch.Elapsed()
 
-        // So I have these ugly ifs, cuz I want the result be printed as it
-        // arrives. In the previous version I got printing defered and these
-        // ifs were super dope and readable (thanks to continue statements).
-        // But defer in a loop executes the printing at the loop's very end
-        // which is unfortunate...
-        // So, here I go. I somebody knows a way prettify this part, I would be
-        // very glad!
         if err := b.Errs[id]; err != nil {
             if errors.Is(err, InternalErr) {
                 b.Stat[id] = IE

--- a/TestingBatch.go
+++ b/TestingBatch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -169,10 +170,17 @@ func (b *TestingBatch) Run() {
             } else {
                 b.Stat[id] = RE
             }
-        } else if test.Output != b.Outs[id] {
-            b.Stat[id] = WA
         } else {
-            b.Stat[id] = OK
+            lexer := Lexer{}
+
+            got := lexer.Scan(b.Outs[id])
+            want := lexer.Scan(test.Output)
+
+            if !reflect.DeepEqual(got, want) {
+                b.Stat[id] = WA
+            } else {
+                b.Stat[id] = OK
+            }
         }
 
         b.TestEndCallback(b, test, id)

--- a/TestingBatch_test.go
+++ b/TestingBatch_test.go
@@ -19,6 +19,19 @@ func ProcFuncMultiply(in io.Reader, out io.Writer) error {
     return nil
 }
 
+func ProcFuncSparseIntegerSequence(in io.Reader, out io.Writer) error {
+    var n int
+    fmt.Fscan(in, &n)
+
+    for i := 1; i <= n; i++ {
+        fmt.Fprint(out, i, "  ")
+    }
+
+    fmt.Fprintln(out, "")
+
+    return nil
+}
+
 func ProcFuncAnswer(in io.Reader, out io.Writer) error {
     fmt.Fprintln(out, 42)
 
@@ -44,6 +57,40 @@ func TestTestingBatch(t *testing.T) {
 
         proc := &cptest.SpyProcesser{
             Proc: cptest.ProcesserFunc(ProcFuncMultiply),
+        }
+
+        swatch := &cptest.SpyStopwatcher{}
+
+        batch := cptest.NewTestingBatch(inputs, proc, swatch)
+
+        batch.Run()
+
+        want := map[int]cptest.Verdict{
+            1: cptest.OK,
+            2: cptest.OK,
+        }
+
+        cptest.AssertVerdicts(t, batch.Stat, want)
+        cptest.AssertCallCount(t, proc.CallCount, 2)
+    })
+
+    t.Run("outputs are compared lexeme-wise",
+    func(t *testing.T) {
+        inputs := cptest.Inputs{
+            Tests: []cptest.Test{
+                {
+                    Input: "2\n",
+                    Output: "1 2\n",
+                },
+                {
+                    Input: "3\n",
+                    Output: "1 2 3\n",
+                },
+            },
+        }
+
+        proc := &cptest.SpyProcesser{
+            Proc: cptest.ProcesserFunc(ProcFuncSparseIntegerSequence),
         }
 
         swatch := &cptest.SpyStopwatcher{}

--- a/cmd/cptest/executable.go
+++ b/cmd/cptest/executable.go
@@ -1,32 +1,15 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os/exec"
-	"strings"
 
 	"github.com/kuredoro/cptest"
 )
 
 type Executable struct {
 	Path string
-}
-
-func trimSpaceLineWise(text string) string {
-	var str strings.Builder
-	s := bufio.NewScanner(strings.NewReader(text))
-
-	for s.Scan() {
-        line := strings.TrimSpace(s.Text())
-        if line != "" {
-            str.WriteString(strings.TrimSpace(s.Text()))
-            str.WriteRune('\n')
-        }
-	}
-
-	return str.String()
 }
 
 func (e *Executable) Run(r io.Reader, w io.Writer) error {
@@ -36,8 +19,7 @@ func (e *Executable) Run(r io.Reader, w io.Writer) error {
 	out, err := cmd.Output()
 
 	if ee, ok := err.(*exec.ExitError); ok {
-		cleanStderr := trimSpaceLineWise(string(ee.Stderr))
-		fmt.Fprint(w, cleanStderr)
+		fmt.Fprint(w, string(ee.Stderr))
 		return fmt.Errorf("%v", ee)
 	}
 
@@ -45,7 +27,6 @@ func (e *Executable) Run(r io.Reader, w io.Writer) error {
 		return fmt.Errorf("%w: %v", cptest.InternalErr, err)
 	}
 
-	cleanOut := trimSpaceLineWise(string(out))
-	fmt.Fprint(w, cleanOut)
+	fmt.Fprint(w, string(out))
 	return nil
 }

--- a/lexer.go
+++ b/lexer.go
@@ -19,7 +19,7 @@ type Lexer struct {
 // \n\n are parsed as separate lexemes ("\n", "\n").
 // It will never return an empty lexeme.
 // The definition of other spaces is set by unicode.IsSpace.
-func scanLexemes(data []byte, atEOF bool) (advance int, token []byte, err error) {
+func ScanLexemes(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	// Skip leading spaces.
 	start := 0
 	for width := 0; start < len(data); start += width {
@@ -66,7 +66,7 @@ func (l *Lexer) Scan(text string) (seq LexSequence) {
 
     r := strings.NewReader(text)
     s := bufio.NewScanner(r)
-    s.Split(scanLexemes)
+    s.Split(ScanLexemes)
 
     for s.Scan() {
         seq = append(seq, s.Text())

--- a/lexer.go
+++ b/lexer.go
@@ -1,0 +1,76 @@
+package cptest
+
+import (
+	"bufio"
+	"strings"
+    "unicode"
+    "unicode/utf8"
+)
+
+type LexSequence []string
+
+type Lexer struct {
+
+}
+
+// ScanLexemes is a split function for bufio.Scanner. It is same as
+// bufio.ScanWords, except that it treats \n character in a special way.
+// \n cannot be in any lexeme, except for "\n" itself. Hence, several
+// \n\n are parsed as separate lexemes ("\n", "\n").
+// It will never return an empty lexeme.
+// The definition of other spaces is set by unicode.IsSpace.
+func scanLexemes(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	// Skip leading spaces.
+	start := 0
+	for width := 0; start < len(data); start += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[start:])
+		if r == '\n' || !unicode.IsSpace(r) {
+			break
+		}
+	}
+
+	// Scan until space, marking end of word.
+	for width, i := 0, start; i < len(data); i += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[i:])
+
+        if r == '\n' {
+            if i == start {
+                return i + width, data[start:i + width], nil
+            }
+
+            return i, data[start:i], nil
+        }
+
+		if unicode.IsSpace(r) {
+			return i + width, data[start:i], nil
+		}
+	}
+
+	// If we're at EOF, we have a final, non-empty, non-terminated word. Return it.
+	if atEOF && len(data) > start {
+		return len(data), data[start:], nil
+	}
+
+	// Request more data.
+	return start, nil, nil
+}
+
+// Scan will break the text into lexemes and return them. A lexeme
+// is either a string consisting of not unicode.IsSpace characters,
+// or a single newline character.
+// The returned LexSequence is never nil.
+func (l *Lexer) Scan(text string) (seq LexSequence) {
+    seq = LexSequence{}
+
+    r := strings.NewReader(text)
+    s := bufio.NewScanner(r)
+    s.Split(scanLexemes)
+
+    for s.Scan() {
+        seq = append(seq, s.Text())
+    }
+
+    return
+}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -1,0 +1,54 @@
+package cptest_test
+
+import (
+    "testing"
+
+    "github.com/kuredoro/cptest"
+)
+
+func TestLexer(t *testing.T) {
+
+    t.Run("empty string",
+    func(t *testing.T) {
+        text := ""
+        want := cptest.LexSequence{}
+
+        lexer := cptest.Lexer{}
+        got := lexer.Scan(text)
+
+        cptest.AssertLexSequence(t, got, want)
+    })
+
+    t.Run("one word",
+    func(t *testing.T) {
+        text := "foo"
+        want := cptest.LexSequence{"foo"}
+
+        lexer := cptest.Lexer{}
+        got := lexer.Scan(text)
+
+        cptest.AssertLexSequence(t, got, want)
+    })
+
+    t.Run("several words",
+    func(t *testing.T) {
+        text := " foo bar   --> "
+        want := cptest.LexSequence{"foo", "bar", "-->"}
+
+        lexer := cptest.Lexer{}
+        got := lexer.Scan(text)
+
+        cptest.AssertLexSequence(t, got, want)
+    })
+
+    t.Run("newline is treated like a word",
+    func(t *testing.T) {
+        text := "one\ntwo\n\n  three \n"
+        want := cptest.LexSequence{"one", "\n", "two", "\n", "\n", "three", "\n"}
+
+        lexer := cptest.Lexer{}
+        got := lexer.Scan(text)
+
+        cptest.AssertLexSequence(t, got, want)
+    })
+}

--- a/testing.go
+++ b/testing.go
@@ -159,3 +159,12 @@ func AssertTimes(t *testing.T, got, want map[int]time.Duration) {
         }
     }
 }
+
+// AssertLexSequence compares if the two LexSequences are equal.
+func AssertLexSequence(t *testing.T, got, want LexSequence) {
+    t.Helper()
+
+    if !reflect.DeepEqual(got, want) {
+        t.Errorf("got %#v, want %#v", got, want)
+    }
+}


### PR DESCRIPTION
Right now, the text in the test cases is space-trimmed line-wise: input and output. Additionally, there's a code duplication for line-wise trimming in `main` package.

This pull request aims to get rid of this space trimming and replace it with lexical analysis. The `ScanInput` and `Executable` shall not do any preprocessing of text. The `TestingBatch` shall create a `Lexer` and use it to extract lexemes from both outputs and compare the sequences themselves with each other.

Consequently, the rules determining if test passes are relaxed since now any amount of space is permitted between any *lexeme*, instead of line.

Also, the newline character shall be its own lexeme. I think it will become handy in the future. As for now, we want any execessive newlines to be detected, so we should not ignore them. But at the same time, we don't want them to mix with the ordinary text. Also, in the future it may be possible upon lexeme mismatch, if one of them is newline to skip until a non-newline lexeme is found, then continue comparison.