### PR TITLE
Concurrency panic fix

### DIFF
--- a/TestingBatch_test.go
+++ b/TestingBatch_test.go
@@ -71,7 +71,7 @@ func TestTestingBatch(t *testing.T) {
 			}
 
 			cptest.AssertVerdicts(t, batch.Verdicts, want)
-			cptest.AssertCallCount(t, proc.CallCount, 2)
+			cptest.AssertCallCount(t, proc.CallCount(), 2)
 		})
 
 	t.Run("outputs are compared lexeme-wise",
@@ -105,7 +105,7 @@ func TestTestingBatch(t *testing.T) {
 			}
 
 			cptest.AssertVerdicts(t, batch.Verdicts, want)
-			cptest.AssertCallCount(t, proc.CallCount, 2)
+			cptest.AssertCallCount(t, proc.CallCount(), 2)
 
 			if batch.Diff.Got == nil || batch.Diff.Want == nil {
 				t.Errorf("got no lex diff data, want some")
@@ -143,7 +143,7 @@ func TestTestingBatch(t *testing.T) {
 			}
 
 			cptest.AssertVerdicts(t, batch.Verdicts, want)
-			cptest.AssertCallCount(t, proc.CallCount, 2)
+			cptest.AssertCallCount(t, proc.CallCount(), 2)
 		})
 
 	t.Run("runtime error and internal error",
@@ -208,7 +208,7 @@ func TestTestingBatch(t *testing.T) {
 			}
 
 			cptest.AssertVerdicts(t, batch.Verdicts, want)
-			cptest.AssertCallCount(t, proc.CallCount, 5)
+			cptest.AssertCallCount(t, proc.CallCount(), 5)
 		})
 
 	t.Run("test cases may be abandoned at TL",
@@ -259,7 +259,7 @@ func TestTestingBatch(t *testing.T) {
 			}
 
 			cptest.AssertVerdicts(t, batch.Verdicts, testsWant)
-			cptest.AssertCallCount(t, proc.CallCount, 4)
+			cptest.AssertCallCount(t, proc.CallCount(), 4)
 			cptest.AssertTimes(t, batch.Times, timesWant)
 		})
 }

--- a/processer.go
+++ b/processer.go
@@ -2,6 +2,7 @@ package cptest
 
 import (
 	"io"
+	"sync"
 )
 
 // Processer interface abstracts away the concept of the executable under
@@ -15,14 +16,25 @@ type Processer interface {
 type SpyProcesser struct {
 	Proc Processer
 
-	CallCount int
+    mu sync.Mutex
+	callCount int
 }
 
 // Run will execute the Run function of the inner processer, but will
 // also increase the call count by one.
 func (p *SpyProcesser) Run(r io.Reader, w io.Writer) error {
-	p.CallCount++
+    p.mu.Lock()
+	p.callCount++
+    p.mu.Unlock()
 	return p.Proc.Run(r, w)
+}
+
+// CallCount will return the number of times Run was called. Can be called
+// concurrently.
+func (p *SpyProcesser) CallCount() int {
+    p.mu.Lock()
+    defer p.mu.Unlock()
+	return p.callCount
 }
 
 // ProcesserFunc represents an implementation of Processer that instead


### PR DESCRIPTION
Should fix #7 and close #1.

For N tests, there are N goroutines created, each calling the specified Processer and updating the state of the `TestingBatch` by writting to `Errs` and `Outs` maps. Before this pull request, the global lock `mu` is locked when Processer finishes and the state needs to be updated. But this lock was not acquired by the parent thread `Run` that created these goroutines when determining the verdict for a test.

A channel that communicated to `Run` that a certain test was finished was already in place. It just returned the ID of the test. This pull request removes the necessity for the lock by also communicating data to be appended to `Errs` and `Outs` with the returned ID. The data is communicated via the channel and the only place where the state of TestingBatch changes is the `Run` method that runs in a single thread.

Also, I just updated the command used by my "test this" keybinding to run with `--race`. Now, it was complaining that `SpyProcesser`'s `CallCount` was not concurrency safe. Oh well :joy_cat: Fixed that also.