### PR TITLE
cptest accepts cmdline arguments and passes to the executable.

### DIFF
--- a/cmd/cptest/executable.go
+++ b/cmd/cptest/executable.go
@@ -11,10 +11,11 @@ import (
 
 type Executable struct {
 	Path string
+    Args []string
 }
 
 func (e *Executable) Run(ctx context.Context, r io.Reader) (cptest.ProcessResult, error) {
-	cmd := exec.Command(e.Path)
+	cmd := exec.Command(e.Path, e.Args...)
 	cmd.Stdin = r
 
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/cmd/cptest/main.go
+++ b/cmd/cptest/main.go
@@ -16,8 +16,9 @@ var stdout = colorable.NewColorableStdout()
 
 type appArgs struct {
 	Inputs     string `arg:"-i" default:"inputs.txt" help:"file with tests"`
-	Executable string `arg:"positional,required"`
 	NoColors   bool   `arg:"--no-colors" help:"disable colored output"`
+	Executable string `arg:"positional,required"`
+    Args   []string `arg:"positional"`
 }
 
 var args appArgs
@@ -71,6 +72,7 @@ func main() {
 	execPath := joinIfRelative(wd, args.Executable)
 	proc := &Executable{
 		Path: execPath,
+        Args: args.Args,
 	}
 	if err != nil {
 		fmt.Printf("error: %v\n", err)


### PR DESCRIPTION
Closes #12 